### PR TITLE
Add secure tip contact page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ReportForm } from './components/ReportForm';
 import { SecurityGuide } from './components/SecurityGuide';
 import { VerificationPage } from './components/VerificationPage';
 import { TestSuite } from './components/TestSuite';
+import { ContactPage } from './components/ContactPage';
 import { PanicButton } from './components/PanicButton';
 import { PerformanceOptimizer } from './components/PerformanceOptimizer';
 import { LoadingOptimizer } from './components/LoadingOptimizer';
@@ -25,6 +26,7 @@ function App() {
               <Route path="/report" element={<ReportForm />} />
               <Route path="/security" element={<SecurityGuide />} />
               <Route path="/verify" element={<VerificationPage />} />
+              <Route path="/tip" element={<ContactPage />} />
               <Route path="/test" element={<TestSuite />} />
             </Routes>
           </div>

--- a/src/components/ContactPage.tsx
+++ b/src/components/ContactPage.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { MessageCircle, Phone, Shield } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export const ContactPage: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 py-12 px-6">
+      <div className="max-w-2xl mx-auto">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center mb-12"
+        >
+          <div className="bg-blue-100 p-4 rounded-full w-16 h-16 mx-auto mb-6 flex items-center justify-center">
+            <Shield className="w-8 h-8 text-blue-600" />
+          </div>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">{t('tip.title')}</h1>
+          <p className="text-xl text-gray-600">{t('tip.subtitle')}</p>
+        </motion.div>
+        <div className="space-y-8">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="bg-white rounded-xl shadow-lg p-8"
+          >
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">{t('tip.whatsappTitle')}</h2>
+            <p className="text-gray-700 mb-4">{t('tip.whatsappBody')}</p>
+            <div className="flex items-center text-blue-700 font-semibold">
+              <MessageCircle className="w-5 h-5 ml-2" />
+              <span>+1 587 457 4532</span>
+            </div>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="bg-white rounded-xl shadow-lg p-8"
+          >
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">{t('tip.signalTitle')}</h2>
+            <p className="text-gray-700 mb-4">{t('tip.signalBody')}</p>
+            <div className="flex items-center text-blue-700 font-semibold">
+              <Phone className="w-5 h-5 ml-2" />
+              <span>+1 587 457 4532</span>
+            </div>
+          </motion.div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -187,6 +187,12 @@ export const HomePage: React.FC = () => {
             {t('securityGuide')}
           </Link>
           <Link
+            to="/tip"
+            className="px-6 py-3 bg-blue-100 hover:bg-blue-200 text-blue-700 rounded-lg transition-colors font-medium"
+          >
+            {t('submitSecurely')}
+          </Link>
+          <Link
             to="/test"
             className="px-6 py-3 bg-indigo-100 hover:bg-indigo-200 text-indigo-700 rounded-lg transition-colors font-medium flex items-center gap-2"
           >

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -28,6 +28,14 @@ const translations = {
       corruption: 'فساد في مؤسسات عامة (سابق أو حالي)',
       econ_corruption: 'فساد في قطاع الأعمال والشركات الخاصة',
       intel: 'معلومات أمنية أو استخباراتية غير عاجلة'
+    },
+    tip: {
+      title: 'مشاركة المعلومات عبر تطبيقات آمنة',
+      subtitle: 'لديك خيار التواصل معنا بشكل أكثر أماناً عبر واتساب أو سيجنال',
+      whatsappTitle: 'التواصل عبر واتساب',
+      whatsappBody: 'استخدم واتساب لإرسال رسائل مشفرة إلينا. تأكد من تعطيل النسخ الاحتياطي السحابي.',
+      signalTitle: 'التواصل عبر سيجنال',
+      signalBody: 'سيجنال يخزن بيانات أقل عن مستخدميه ويوفر رسائل ذاتية الاختفاء.'
     }
   },
   fa: {
@@ -49,6 +57,14 @@ const translations = {
       corruption: 'فساد در نهادهای عمومی (قبلی یا فعلی)',
       econ_corruption: 'فساد در بخش تجاری و شرکت‌های خصوصی',
       intel: 'اطلاعات امنیتی یا اطلاعاتی غیر فوری'
+    },
+    tip: {
+      title: 'اشتراک‌گذاری اطلاعات از طریق پیام‌رسان‌های امن',
+      subtitle: 'می‌توانید از واتس‌اپ یا سیگنال برای برقراری ارتباط امن استفاده کنید.',
+      whatsappTitle: 'تماس از طریق واتس‌اپ',
+      whatsappBody: 'پیام‌های واتس‌اپ رمزگذاری شده‌اند. پشتیبان‌گیری ابری را غیرفعال کنید.',
+      signalTitle: 'تماس از طریق سیگنال',
+      signalBody: 'سیگنال اطلاعات کمتری ذخیره می‌کند و امکان حذف خودکار پیام‌ها را دارد.'
     }
   },
   en: {
@@ -70,6 +86,14 @@ const translations = {
       corruption: 'Corruption in public institutions (past or current)',
       econ_corruption: 'Corruption in business sector and private companies',
       intel: 'Non-urgent security or intelligence information'
+    },
+    tip: {
+      title: 'Submit a Tip Securely',
+      subtitle: 'You can reach us through encrypted WhatsApp or Signal messages.',
+      whatsappTitle: 'Contact via WhatsApp',
+      whatsappBody: 'Use WhatsApp to send encrypted messages. Disable cloud backups.',
+      signalTitle: 'Contact via Signal',
+      signalBody: 'Signal stores minimal metadata and supports disappearing messages.'
     }
   }
 };


### PR DESCRIPTION
## Summary
- introduce `ContactPage` for tip submission via WhatsApp or Signal
- translate tip sharing instructions in Arabic, Farsi, and English
- link the tip page from the Home page and add routing in `App.tsx`
- use a generic message icon in place of a missing WhatsApp logo

## Testing
- `npm run lint` *(fails: various TypeScript ESLint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875a7e5598c8323adf860505fa3537a